### PR TITLE
Fix device mismatch in g1_29dof/dex3 obs functions on Isaac Sim 6.0

### DIFF
--- a/tasks/common_observations/dex3_state.py
+++ b/tasks/common_observations/dex3_state.py
@@ -99,10 +99,11 @@ def get_robot_dex3_joint_states(
         torch.Tensor
     """
     # get the gripper joint positions, velocities, torques
-    joint_pos = env.scene["robot"].data.joint_pos
-    joint_vel = env.scene["robot"].data.joint_vel  
-    joint_torque = env.scene["robot"].data.applied_torque
-    device = joint_pos.device
+    # HANDSIM PATCH 2026-05-26: see g1_29dof_state.py — same prepare_terms device mix.
+    device = env.device
+    joint_pos = env.scene["robot"].data.joint_pos.to(device)
+    joint_vel = env.scene["robot"].data.joint_vel.to(device)
+    joint_torque = env.scene["robot"].data.applied_torque.to(device)
     batch = joint_pos.shape[0]
     
 

--- a/tasks/common_observations/g1_29dof_state.py
+++ b/tasks/common_observations/g1_29dof_state.py
@@ -156,10 +156,14 @@ def get_robot_boy_joint_states(
         - the last 29 elements are joint torques
     """
     # get all joint states
-    joint_pos = env.scene["robot"].data.joint_pos
-    joint_vel = env.scene["robot"].data.joint_vel
-    joint_torque = env.scene["robot"].data.applied_torque  # use applied_torque to get joint torques
-    device = joint_pos.device
+    # HANDSIM PATCH 2026-05-26: on the first call (ObservationManager._prepare_terms,
+    # before any sim step) joint_pos can still live on CPU while applied_torque is
+    # already on cuda:0 — that mixes devices in the torch.gather below. Force
+    # everything onto env.device so the cache + gather stay consistent.
+    device = env.device
+    joint_pos = env.scene["robot"].data.joint_pos.to(device)
+    joint_vel = env.scene["robot"].data.joint_vel.to(device)
+    joint_torque = env.scene["robot"].data.applied_torque.to(device)
     batch = joint_pos.shape[0]
 
     # 预计算并缓存索引张量（列索引）


### PR DESCRIPTION
## Reproducer

On Isaac Sim 6.0 + IsaacLab `main` (Ubuntu 24.04, Python 3.12), construct the env directly so the failure isn't hidden behind sim_main's catch block:

```python
import os
REPO = "/path/to/unitree_sim_isaaclab"
os.chdir(REPO); os.environ["PROJECT_ROOT"] = REPO; os.environ["OMNI_KIT_ACCEPT_EULA"] = "YES"
import sys, argparse; sys.path.insert(0, REPO)
from isaaclab.app import AppLauncher
ap = argparse.ArgumentParser(); AppLauncher.add_app_launcher_args(ap)
_app = AppLauncher(ap.parse_args(["--headless", "--enable_cameras"])).app
import gymnasium as gym, tasks
from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
cfg = parse_env_cfg("Isaac-Move-Cylinder-G129-Dex3-Wholebody", device="cuda:0", num_envs=1); cfg.seed = 42
env = gym.make("Isaac-Move-Cylinder-G129-Dex3-Wholebody", cfg=cfg).unwrapped
```

Result:

```
File "tasks/common_observations/g1_29dof_state.py", line 195, in get_robot_boy_joint_states
    torch.gather(joint_torque, 1, idx_batch, out=torque_buf)
RuntimeError: Expected all tensors to be on the same device, but found at least
two devices, cpu and cuda:0! (when checking argument for argument self in method
wrapper_CUDA_gather_out_out)
```

This happens during `ObservationManager._prepare_terms` — before the sim has stepped, the articulation hasn't fully moved to the configured device. `joint_pos` still lives on CPU while `applied_torque` is already on `cuda:0`. The cached `boy_idx_batch` is built on `joint_pos.device` (CPU), then `torch.gather(joint_torque, …, out=torque_buf)` crashes.

## Fix

Use `env.device` as the canonical device and force the three input tensors onto it via `.to(device)` (no-op when already on that device). The cache is then consistently built and the gather succeeds on the first call too.

Same pattern in `tasks/common_observations/dex3_state.py::get_robot_dex3_joint_states`.

## Rationale

`env.device` is the configured simulation device and is unambiguous regardless of when in the env lifecycle the obs function is called. Anchoring on `joint_pos.device` was an implicit assumption that articulation tensors had all migrated to that device, which holds after the first step but not before it.

## Verified

- Env construction completes on Isaac Sim 6.0 + IsaacLab main without the device-mismatch traceback.
- The fix is a no-op on Isaac Sim 4.5 / 5.x where the articulation is already on the configured device by `_prepare_terms` time.