### PR TITLE
Print full traceback when env creation fails

### DIFF
--- a/sim_main.py
+++ b/sim_main.py
@@ -309,7 +309,9 @@ def main():
         except Exception as e:
             print(f"[camera] failed to apply writer options: {e}")
     except Exception as e:
+        import traceback
         print(f"\nFailed to create environment: {e}")
+        traceback.print_exc()
         return
     
     # get robot stiffness and damping parameters from runtime environment


### PR DESCRIPTION
## Problem

Today the env-creation handler in `sim_main.py` swallows the stack and prints only `str(e)`:

```python
except Exception as e:
    print(f"\nFailed to create environment: {e}")
    return
```

So failures during `gym.make()` or any of the downstream env tweaks (sensor list, render config, physx params, MDL loader…) surface as a single line like

```
Failed to create environment: Expected all tensors to be on the same device,
but found at least two devices, cpu and cuda:0!
```

with no indication of WHICH line in WHICH file raised. The debug cycle becomes "inject print statements, rerun the sim (slow), remove print statements" instead of just reading the actual traceback.

## Fix

Add `import traceback; traceback.print_exc()` inside the catch. The existing one-line message is kept, followed by the full stack.

## Rationale

Zero behavior change on the happy path. On failure, the user gets the file/line where the env init blew up, which is the missing piece needed to fix the underlying problem. Two-line patch, no new dependency.