### PR TITLE
Force "lo" interface in DDS bootstrap

### DIFF
--- a/dds/dds_master.py
+++ b/dds/dds_master.py
@@ -57,9 +57,15 @@ class DDSManager:
             return True
         
         try:
-            ChannelFactoryInitialize(1)
+            # HANDSIM PATCH 2026-05-26: explicit "lo" interface so cross-process
+            # DDS discovery works on Ubuntu 24.04. Autodetermine picked an
+            # interface that lacked working multicast, so external publishers
+            # (e.g. WBC composer, GR00T-driven goal sender) couldn't reach the
+            # sim's rt/lowstate subscribers. cyclonedds falls back to unicast
+            # on lo and that works fine for local cross-process IPC.
+            ChannelFactoryInitialize(1, "lo")
             self.dds_initialized = True
-            print("[DDSManager] DDS system initialized")
+            print("[DDSManager] DDS system initialized (forced lo interface)")
             return True
         except Exception as e:
             print(f"[DDSManager] DDS system initialization failed: {e}")


### PR DESCRIPTION
## Problem

`DDSManager._init_dds` calls `ChannelFactoryInitialize(1)` with no interface argument. CycloneDDS then runs auto-detect and picks the first qualifying interface. On Ubuntu 24.04 (and any modern Linux where the auto-pick lands on a non-multicast-capable interface) cross-process DDS discovery silently breaks — same-process pub/sub works, but two separate Python processes both calling `ChannelFactoryInitialize(1)` never see each other's messages.

This is fatal for the intended use case: any external process (WBC composer, VR teleop, GR00T-driven policy, custom test harness) can't reach the `rt/lowstate` the sim publishes, and the sim never receives the `rt/lowcmd` they publish.

## Reproducer (no sim needed)

Terminal A:
```bash
python -c '
from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelPublisher
from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
from unitree_sdk2py.idl.default import unitree_hg_msg_dds__LowState_
import time
ChannelFactoryInitialize(1)
pub = ChannelPublisher("rt/test", LowState_); pub.Init()
time.sleep(1)
for _ in range(30):
    pub.Write(unitree_hg_msg_dds__LowState_()); time.sleep(0.1)
'
```

Terminal B:
```bash
python -c '
from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelSubscriber
from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
import time
ChannelFactoryInitialize(1)
n = [0]
ChannelSubscriber("rt/test", LowState_).Init(lambda m: n.__setitem__(0, n[0]+1), 32)
time.sleep(5); print(f"received {n[0]}")
'
# → received 0
```

Switch both ends to `ChannelFactoryInitialize(1, "lo")` and the subscriber receives all 30 frames.

## Fix

`ChannelFactoryInitialize(1)` → `ChannelFactoryInitialize(1, "lo")` in `dds/dds_master.py::_init_dds`.

CycloneDDS prints `selected interface "lo" is not multicast-capable: disabling multicast` and falls back to unicast on the loopback. That's correct for local cross-process IPC and removes the discovery hole.

## Rationale

The sim is intentionally designed to be driven by a separate controller process (real robot or external composer), so cross-process discovery on the host needs to work reliably. Hard-coding `lo` is the right default for the sim's "local development" mode. Operators on real hardware can still pass an explicit interface name to `ChannelFactoryInitialize` if they need to override.