### PR TITLE
Add UNITREE_SIM_SUPPRESS_ROOM_WALLS env var to disable warehouse mesh

### DIFF
--- a/tasks/common_scene/base_scene_pickplace_cylindercfg_wholebody.py
+++ b/tasks/common_scene/base_scene_pickplace_cylindercfg_wholebody.py
@@ -13,22 +13,36 @@ from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from tasks.common_config import   CameraBaseCfg  # isort: skip
 import os
 project_root = os.environ.get("PROJECT_ROOT")
+_SUPPRESS_ROOM_WALLS = os.environ.get("UNITREE_SIM_SUPPRESS_ROOM_WALLS", "0") == "1"
+
+
 @configclass
 class TableCylinderSceneCfgWH(InteractiveSceneCfg): # inherit from the interactive scene configuration class
     """object table scene configuration class
     defines a complete scene containing robot, object, table, etc.
+
+    Setting ``UNITREE_SIM_SUPPRESS_ROOM_WALLS=1`` in the environment swaps the
+    warehouse mesh out for a plain ground plane. The walls don't carry any
+    task semantics — they're decorative — but they block the default world
+    camera view of the robot, which makes headed development awkward.
     """
-      # 1. room wall configuration - simplified configuration to avoid rigid body property conflicts
-    room_walls = AssetBaseCfg(
-        prim_path="/World/envs/env_.*/Room",
-        init_state=AssetBaseCfg.InitialStateCfg(
-            pos=[0.0, 0.0, 0],  # room center point
-            rot=[1.0, 0.0, 0.0, 0.0]
-        ),
-        spawn=UsdFileCfg(
-            usd_path=f"{project_root}/assets/objects/small_warehouse/small_warehouse_digital_twin.usd",
-        ),
-    )
+    if _SUPPRESS_ROOM_WALLS:
+        ground = AssetBaseCfg(
+            prim_path="/World/Ground",
+            spawn=GroundPlaneCfg(),
+        )
+    else:
+        # 1. room wall configuration - simplified configuration to avoid rigid body property conflicts
+        room_walls = AssetBaseCfg(
+            prim_path="/World/envs/env_.*/Room",
+            init_state=AssetBaseCfg.InitialStateCfg(
+                pos=[0.0, 0.0, 0],  # room center point
+                rot=[1.0, 0.0, 0.0, 0.0]
+            ),
+            spawn=UsdFileCfg(
+                usd_path=f"{project_root}/assets/objects/small_warehouse/small_warehouse_digital_twin.usd",
+            ),
+        )
 
 
         # 1. table configuration


### PR DESCRIPTION
## Problem

The `small_warehouse_digital_twin.usd` room walls in `TableCylinderSceneCfgWH` don't carry any task semantics for the {PickPlace, Stack, MoveCylinder}-*-Wholebody tasks — they're decorative geometry. But the default `world_camera` (defined later in the same scene cfg, mounted at `/World/PerspectiveCamera`) sits inside the warehouse and looks at the robot through a wall corner, which renders the headed viewport mostly useless for visualization during development.

The current README's "click PerspectiveCamera → Cameras → PerspectiveCamera to view the main view" workaround means every dev has to manually re-aim the camera each launch, and even after that the walls clip the view.

## Fix

Gate the `room_walls` AssetBaseCfg on an environment variable:

```python
_SUPPRESS_ROOM_WALLS = os.environ.get("UNITREE_SIM_SUPPRESS_ROOM_WALLS", "0") == "1"

@configclass
class TableCylinderSceneCfgWH(InteractiveSceneCfg):
    if _SUPPRESS_ROOM_WALLS:
        ground = AssetBaseCfg(prim_path="/World/Ground", spawn=GroundPlaneCfg())
    else:
        room_walls = AssetBaseCfg(...)  # original
```

Default behavior is unchanged. With `UNITREE_SIM_SUPPRESS_ROOM_WALLS=1` set, the warehouse is replaced by a global GroundPlane and the world_camera frame is unobstructed.

## Reproducer

Default (walls on):
```bash
python sim_main.py --task Isaac-Move-Cylinder-G129-Dex3-Wholebody \
  --enable_cameras --enable_dex3_dds --enable_wholebody_dds \
  --action_source dds_wholebody
# headed viewport shows warehouse interior; robot is partially hidden by a wall.
```

With env var:
```bash
UNITREE_SIM_SUPPRESS_ROOM_WALLS=1 python sim_main.py …
# robot + tables + cylinder visible on a plain ground plane, unobstructed.
```

## Rationale

`TableCylinderSceneCfgWH` is shared across multiple task env_cfgs (`pickplace_cylinder`, `move_cylinder`, `stack_rgyblock` variants). Threading a config flag through every consumer is invasive; class-body conditional on an env var is the minimal change.

GroundPlane goes at a global `/World/Ground` path because `GroundPlaneCfg.func` (`spawn_ground_plane`) doesn't substitute the `/envs/env_.*` wildcard and a per-env ground plane errors out.

Lower priority than the bug-fix PRs (this is a dev ergonomics change, not a correctness fix). Happy to drop or rework if upstream prefers a different surface for the toggle.