### PR TITLE
Add --wbc_internal to run GR00T-WBC Balance/Walk ONNX in-process

### DIFF
--- a/action_provider/action_provider_wh_dds.py
+++ b/action_provider/action_provider_wh_dds.py
@@ -23,6 +23,10 @@ class DDSRLActionProvider(ActionProvider):
         self.enable_dex3 = args_cli.enable_dex3_dds
         self.enable_inspire = args_cli.enable_inspire_dds
         self.wh = args_cli.enable_wholebody_dds
+        # When True, GR00T-WBC Balance/Walk ONNX runs INSIDE this process
+        # from tick 1 (no DDS round-trip). nav_cmd still comes from the
+        # rt/run_command/cmd topic; bundled policy.onnx is disabled.
+        self.wbc_internal = bool(getattr(args_cli, "wbc_internal", False))
         self.policy_path = f"{project_root}/"+args_cli.model_path
         self.env = env
         # Initialize DDS communication
@@ -33,8 +37,26 @@ class DDSRLActionProvider(ActionProvider):
         self.run_command = None
         self._setup_dds()
         self._setup_joint_mapping()
-        self.policy = self.load_policy(self.policy_path)
-        
+        # Skip loading the bundled policy under wbc_internal — the
+        # GR00T-WBC checkpoints drive legs+waist instead.
+        if self.wbc_internal:
+            self.policy = None
+        else:
+            self.policy = self.load_policy(self.policy_path)
+
+        # GR00T-WBC inference (Balance/Walk ONNX) — instantiated under
+        # --wbc_internal. Checkpoint directory is overridable via the
+        # GROOT_WBC_ONNX_DIR env var.
+        self._wbc_ctrl = None
+        if self.wbc_internal:
+            from control.lower_body_controller import LowerBodyController
+            onnx_dir = os.environ.get(
+                "GROOT_WBC_ONNX_DIR",
+                os.path.join(project_root or ".", "assets/model/groot_wbc"),
+            )
+            self._wbc_ctrl = LowerBodyController(onnx_dir=onnx_dir)
+            print(f"[{self.name}] WBC internal: loaded Balance + Walk ONNX from {onnx_dir}")
+
         # 预计算索引张量与复用缓冲
         device = self.env.device
         if hasattr(self, "arm_joint_mapping") and self.arm_joint_mapping:
@@ -70,6 +92,33 @@ class DDSRLActionProvider(ActionProvider):
         
         self._full_action_buf = torch.zeros(len(self.all_joint_names), device=device, dtype=torch.float32)
         self._positions_buf = torch.empty(29, device=device, dtype=torch.float32)
+
+        # WBC leg + waist USD-index tensors, used by --wbc_internal to
+        # write the 15-D ONNX output into the composite-asset joint
+        # targets. Joint names are the canonical 15-joint WBC order.
+        _WBC_LEG_NAMES = [
+            "left_hip_pitch_joint", "left_hip_roll_joint", "left_hip_yaw_joint",
+            "left_knee_joint", "left_ankle_pitch_joint", "left_ankle_roll_joint",
+            "right_hip_pitch_joint", "right_hip_roll_joint", "right_hip_yaw_joint",
+            "right_knee_joint", "right_ankle_pitch_joint", "right_ankle_roll_joint",
+        ]
+        _WBC_WAIST_NAMES = ["waist_yaw_joint", "waist_roll_joint", "waist_pitch_joint"]
+        try:
+            self._wbc_leg_target_idx_t = torch.tensor(
+                [self.joint_to_index[n] for n in _WBC_LEG_NAMES],
+                dtype=torch.long, device=device,
+            )
+            self._wbc_waist_target_idx_t = torch.tensor(
+                [self.joint_to_index[n] for n in _WBC_WAIST_NAMES],
+                dtype=torch.long, device=device,
+            )
+        except KeyError as _e:
+            # Asset is missing one of the WBC joint names — wbc_internal
+            # cannot run. Bundled-policy path is unaffected.
+            print(f"[{self.name}] WBC index setup skipped (joint not found): {_e}")
+            self._wbc_leg_target_idx_t = None
+            self._wbc_waist_target_idx_t = None
+
         if self.enable_gripper:
             self._gripper_buf = torch.empty(2, device=device, dtype=torch.float32)
         if self.enable_dex3:
@@ -372,16 +421,105 @@ class DDSRLActionProvider(ActionProvider):
         current_actor_obs = self.compute_observations()
         action = self.policy(current_actor_obs)
         return action
+
+    def _wbc_internal_step(self) -> Optional[torch.Tensor]:
+        """Run GR00T-WBC Balance/Walk ONNX in-process. Returns a 15-D
+        tensor of absolute joint targets (12 legs + 3 waist) in WBC
+        joint order, or None if WBC isn't loaded."""
+        if self._wbc_ctrl is None:
+            return None
+        import numpy as _np
+        # Pull current state from IsaacLab directly — no DDS round-trip.
+        # Works from tick 1, before any external publisher would be up.
+        data = self.env.scene["robot"].data
+        jp = data.joint_pos[0].detach().cpu().numpy()
+        jv = data.joint_vel[0].detach().cpu().numpy()
+        # Build USD-index list for the 29-D canonical body order on first
+        # call, then reuse.
+        if not hasattr(self, "_wbc_body_name_indices"):
+            names = [
+                "left_hip_pitch_joint", "left_hip_roll_joint", "left_hip_yaw_joint",
+                "left_knee_joint", "left_ankle_pitch_joint", "left_ankle_roll_joint",
+                "right_hip_pitch_joint", "right_hip_roll_joint", "right_hip_yaw_joint",
+                "right_knee_joint", "right_ankle_pitch_joint", "right_ankle_roll_joint",
+                "waist_yaw_joint", "waist_roll_joint", "waist_pitch_joint",
+                "left_shoulder_pitch_joint", "left_shoulder_roll_joint",
+                "left_shoulder_yaw_joint", "left_elbow_joint",
+                "left_wrist_roll_joint", "left_wrist_pitch_joint", "left_wrist_yaw_joint",
+                "right_shoulder_pitch_joint", "right_shoulder_roll_joint",
+                "right_shoulder_yaw_joint", "right_elbow_joint",
+                "right_wrist_roll_joint", "right_wrist_pitch_joint", "right_wrist_yaw_joint",
+            ]
+            self._wbc_body_name_indices = [self.joint_to_index[n] for n in names]
+        body_idx = self._wbc_body_name_indices
+        legs_q = jp[body_idx[0:12]].astype(_np.float32)
+        waist_q = jp[body_idx[12:15]].astype(_np.float32)
+        arms_q = jp[body_idx[15:29]].astype(_np.float32)
+        legs_dq = jv[body_idx[0:12]].astype(_np.float32)
+        waist_dq = jv[body_idx[12:15]].astype(_np.float32)
+        arms_dq = jv[body_idx[15:29]].astype(_np.float32)
+        # Root quat (wxyz) from IsaacLab → WBC wants xyzw.
+        root_q_wxyz = data.root_quat_w[0].detach().cpu().numpy()
+        root_q_xyzw = _np.array(
+            [root_q_wxyz[1], root_q_wxyz[2], root_q_wxyz[3], root_q_wxyz[0]],
+            dtype=_np.float32,
+        )
+        proj_g = data.projected_gravity_b[0].detach().cpu().numpy().astype(_np.float32)
+        base_ang_vel = data.root_ang_vel_b[0].detach().cpu().numpy().astype(_np.float32)
+        # nav_cmd + height_cmd come from the existing rt/run_command/cmd
+        # DDS topic. Default to (0, 0, 0) + standing height when absent.
+        nav_cmd = _np.zeros(3, dtype=_np.float32)
+        height_cmd = 0.74
+        try:
+            rc = self.run_command_dds.get_run_command() if hasattr(self, "run_command_dds") else None
+            if rc and "run_command" in rc:
+                rcv = rc["run_command"]
+                rcl = ast.literal_eval(rcv) if isinstance(rcv, str) else rcv
+                if isinstance(rcl, (list, tuple)) and len(rcl) >= 4:
+                    nav_cmd[0] = float(rcl[0])
+                    nav_cmd[1] = float(rcl[1])
+                    nav_cmd[2] = float(rcl[2])
+                    height_cmd = float(rcl[3])
+        except Exception:
+            pass
+        lower_q = self._wbc_ctrl.step(
+            legs_q=legs_q, legs_dq=legs_dq,
+            waist_q=waist_q, waist_dq=waist_dq,
+            arms_q=arms_q, arms_dq=arms_dq,
+            base_quat_xyzw=root_q_xyzw,
+            base_ang_vel=base_ang_vel,
+            navigate_cmd=nav_cmd,
+            base_height_cmd=height_cmd,
+            projected_gravity=proj_g,
+        )
+        return torch.tensor(lower_q, dtype=torch.float32, device=self.env.device)
+
     def get_action(self, env) -> Optional[torch.Tensor]:
         """Get action from DDS"""
         try:
             full_action = self._full_action_buf
             full_action.zero_()
-            action_data = self.run_policy()
 
-            # RL 输出与腰部默认位姿
-            full_action[self.action_to_indices] = action_data
-            full_action[self.waist_to_all_indices] = self.default_waist_positions
+            if self.wbc_internal:
+                # In-process WBC: pull state from sim, run Balance/Walk
+                # ONNX, write 15-D lower-body output to legs (USD slots
+                # mapped from canonical 0..11) + waist (12..14).
+                lower_q = self._wbc_internal_step()
+                if lower_q is not None and self._wbc_leg_target_idx_t is not None:
+                    full_action.index_copy_(0, self._wbc_leg_target_idx_t, lower_q[:12])
+                    full_action.index_copy_(0, self._wbc_waist_target_idx_t, lower_q[12:15])
+                else:
+                    # WBC not ready (e.g., first tick before ONNX loaded
+                    # or asset missing a joint) — hold default standing pose.
+                    full_action[self.action_to_indices] = (
+                        self.default_action_positions[:, self.action_to_indices]
+                    )
+                    full_action[self.waist_to_all_indices] = self.default_waist_positions
+            else:
+                action_data = self.run_policy()
+                # RL 输出与腰部默认位姿
+                full_action[self.action_to_indices] = action_data
+                full_action[self.waist_to_all_indices] = self.default_waist_positions
             # 机器人指令（若有）
             if self.enable_robot == "g129" and self.robot_dds:
                 cmd_data = self.robot_dds.get_robot_command()
@@ -391,11 +529,16 @@ class DDSRLActionProvider(ActionProvider):
                         self._positions_buf[:29].copy_(torch.tensor(positions[:29], dtype=torch.float32, device=self.env.device))
                         arm_vals = self._positions_buf.index_select(0, self._arm_source_idx_t)
                         full_action.index_copy_(0, self._arm_target_idx_t, arm_vals)
-            # 延时/裁剪/缩放
-            delayed_actions = self.action_buffer.compute(full_action[self.old_action_indices].unsqueeze(0))
-            cliped_actions = torch.clip(delayed_actions[:,self.action_to_indices], -self.clip_actions, self.clip_actions).to(self.env.device)
-            full_action[self.action_to_indices] = cliped_actions * self.action_scale + self.default_action_positions[:, self.action_to_indices]
-            
+            if not self.wbc_internal:
+                # 延时/裁剪/缩放 — bundled-policy mode only.
+                # --wbc_internal already wrote absolute joint targets
+                # (action_scale + default_angles applied inside
+                # LowerBodyController.step), so re-scaling here would
+                # corrupt the WBC output.
+                delayed_actions = self.action_buffer.compute(full_action[self.old_action_indices].unsqueeze(0))
+                cliped_actions = torch.clip(delayed_actions[:,self.action_to_indices], -self.clip_actions, self.clip_actions).to(self.env.device)
+                full_action[self.action_to_indices] = cliped_actions * self.action_scale + self.default_action_positions[:, self.action_to_indices]
+
             # 夹爪/手指（若有）
             if self.gripper_dds and hasattr(self, "_gripper_source_idx_t"):
                 gripper_cmd = self.gripper_dds.get_gripper_command()

--- a/control/__init__.py
+++ b/control/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025, Unitree Robotics Co., Ltd. All Rights Reserved.
+# License: Apache License, Version 2.0

--- a/control/lower_body_controller.py
+++ b/control/lower_body_controller.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2025, Unitree Robotics Co., Ltd. All Rights Reserved.
+# License: Apache License, Version 2.0
+"""In-process GR00T-WBC lower-body controller.
+
+Wraps NVIDIA's ``GR00T-WholeBodyControl-Balance.onnx`` +
+``GR00T-WholeBodyControl-Walk.onnx`` checkpoints and exposes a single
+``step()`` that consumes the locomotion command (vx, vy, omega, height)
+and current robot state, then emits 15-D absolute joint targets
+(12 legs + 3 waist) ready to write into ``rt/lowcmd`` slots 0..14 or
+directly into the IsaacLab joint-target buffer.
+
+Inference is pure NumPy + onnxruntime; no torch dependency.
+
+Observation layout (86-D per frame, 6-frame history → 516-D input):
+    0:3    nav_cmd * cmd_scale
+    3      base_height_cmd
+    4:7    torso_rpy_cmd
+    7:10   base_ang_vel * ang_vel_scale
+    10:13  projected_gravity (body frame)
+    13:42  (qj - default_angles_29) * dof_pos_scale   (29-D body order)
+    42:71  dqj * dof_vel_scale                         (29-D body order)
+    71:86  last raw action (15-D)
+"""
+
+from __future__ import annotations
+
+import collections
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import onnxruntime as ort
+
+
+def _project_gravity(quat_xyzw: np.ndarray) -> np.ndarray:
+    """Rotate world gravity [0, 0, -1] into the body frame using a
+    quaternion in (x, y, z, w) order — the convention published on
+    ``rt/lowstate`` by ``dds/g1_robot_dds.py``.
+
+    Standing upright with identity quaternion the result is [0, 0, -1].
+    """
+    x, y, z, w = quat_xyzw.astype(np.float32)
+    return np.array(
+        [
+            -2.0 * (x * z - w * y),
+            -2.0 * (y * z + w * x),
+            -(1.0 - 2.0 * (x * x + y * y)),
+        ],
+        dtype=np.float32,
+    )
+
+
+def _quat_inverse_xyzw(q: np.ndarray) -> np.ndarray:
+    return np.array([-q[0], -q[1], -q[2], q[3]], dtype=np.float32)
+
+
+def _quat_multiply_xyzw(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    x1, y1, z1, w1 = q1
+    x2, y2, z2, w2 = q2
+    return np.array(
+        [
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        ],
+        dtype=np.float32,
+    )
+
+
+class LowerBodyController:
+    """GR00T-WBC Balance + Walk wrapper.
+
+    Joint order (15-D output, matches Balance/Walk ONNX export):
+        0..5   left  leg (hip_pitch, hip_roll, hip_yaw, knee, ank_pitch, ank_roll)
+        6..11  right leg (same order)
+        12..14 waist (yaw, roll, pitch)
+
+    29-D body order used for obs assembly (matches DDS slot order):
+        0..11  legs (left then right)
+        12..14 waist
+        15..21 left  arm (shoulder_pitch, _roll, _yaw, elbow,
+                           wrist_roll, _pitch, _yaw)
+        22..28 right arm (same order)
+    """
+
+    BALANCE_PATH = "GR00T-WholeBodyControl-Balance.onnx"
+    WALK_PATH = "GR00T-WholeBodyControl-Walk.onnx"
+    SWITCH_THRESH = 0.05  # |nav_cmd| < this → Balance; else Walk.
+
+    # GR00T-WBC default angles (15-D lower body only).
+    DEFAULT_ANGLES_15 = np.array(
+        [
+            -0.1, 0.0, 0.0, 0.3, -0.2, 0.0,   # left leg
+            -0.1, 0.0, 0.0, 0.3, -0.2, 0.0,   # right leg
+             0.0, 0.0, 0.0,                   # waist
+        ],
+        dtype=np.float32,
+    )
+
+    NUM_BODY_DOF = 29
+    NUM_LOWER = 15
+    SINGLE_OBS_DIM = 86
+    OBS_HISTORY = 6
+    NUM_OBS = SINGLE_OBS_DIM * OBS_HISTORY  # 516
+
+    ACTION_SCALE = 0.25
+    CMD_SCALE = np.array([2.0, 2.0, 0.5], dtype=np.float32)
+    ANG_VEL_SCALE = 0.5
+    DOF_POS_SCALE = 1.0
+    DOF_VEL_SCALE = 0.05
+
+    def __init__(
+        self,
+        onnx_dir: str | Path,
+        providers: Sequence[str] | None = None,
+    ) -> None:
+        onnx_dir = Path(onnx_dir)
+        balance_path = onnx_dir / self.BALANCE_PATH
+        walk_path = onnx_dir / self.WALK_PATH
+        if not balance_path.exists():
+            raise FileNotFoundError(f"Balance ONNX not found: {balance_path}")
+        if not walk_path.exists():
+            raise FileNotFoundError(f"Walk ONNX not found: {walk_path}")
+        if providers is None:
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        self._balance = ort.InferenceSession(str(balance_path), providers=list(providers))
+        self._walk = ort.InferenceSession(str(walk_path), providers=list(providers))
+        self._input_name = self._balance.get_inputs()[0].name
+
+        self._history: collections.deque[np.ndarray] = collections.deque(
+            maxlen=self.OBS_HISTORY
+        )
+        # "last action" slot of the obs (positions 71..85) is the
+        # previous raw output of whichever WBC ran last tick.
+        self._last_action = np.zeros(self.NUM_LOWER, dtype=np.float32)
+        # Optional spawn-quat calibration: maps the USD's raw root quat at
+        # spawn to identity, so projected_gravity computed from quat is
+        # canonical even if the USD's root link has a non-anatomical basis.
+        self._calibration_inv: np.ndarray | None = None
+        # Pre-allocated buffers reused per tick.
+        self._single_obs = np.zeros(self.SINGLE_OBS_DIM, dtype=np.float32)
+        self._obs_buf = np.zeros(self.NUM_OBS, dtype=np.float32)
+        self._padded_defaults = np.zeros(self.NUM_BODY_DOF, dtype=np.float32)
+        self._padded_defaults[: self.NUM_LOWER] = self.DEFAULT_ANGLES_15
+
+    # ------------------------------------------------------------------ public
+    def reset(self) -> None:
+        self._history.clear()
+        self._last_action[:] = 0.0
+
+    def calibrate_spawn_quat(self, q_spawn_xyzw: np.ndarray) -> None:
+        """Treat the given quaternion as the body-frame identity going
+        forward. Idempotent."""
+        self._calibration_inv = _quat_inverse_xyzw(
+            np.asarray(q_spawn_xyzw, dtype=np.float32)
+        )
+
+    def step(
+        self,
+        legs_q: np.ndarray,           # (12,)
+        legs_dq: np.ndarray,          # (12,)
+        waist_q: np.ndarray,          # (3,)
+        waist_dq: np.ndarray,         # (3,)
+        arms_q: np.ndarray,           # (14,)
+        arms_dq: np.ndarray,          # (14,)
+        base_quat_xyzw: np.ndarray,   # (4,) x, y, z, w
+        base_ang_vel: np.ndarray,     # (3,) rad/s, body frame
+        navigate_cmd: np.ndarray,     # (3,) vx, vy, omega
+        base_height_cmd: float,
+        torso_rpy_cmd: Sequence[float] = (0.0, 0.0, 0.0),
+        projected_gravity: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Run one inference step. Returns (15,) float32 absolute joint
+        position targets for the lower body in WBC joint order.
+
+        The returned values are already in radians (action_scale +
+        default_angles applied here), so the caller can write them
+        directly into joint targets without further scaling.
+        """
+        nav = np.asarray(navigate_cmd, dtype=np.float32).reshape(-1)[:3]
+        pg = (
+            np.asarray(projected_gravity, dtype=np.float32).reshape(-1)[:3]
+            if projected_gravity is not None else None
+        )
+        single = self._build_single_obs(
+            nav_cmd=nav,
+            height_cmd=float(base_height_cmd),
+            rpy_cmd=np.asarray(torso_rpy_cmd, dtype=np.float32),
+            base_ang_vel=np.asarray(base_ang_vel, dtype=np.float32),
+            base_quat_xyzw=np.asarray(base_quat_xyzw, dtype=np.float32),
+            projected_gravity=pg,
+            legs_q=np.asarray(legs_q, dtype=np.float32),
+            waist_q=np.asarray(waist_q, dtype=np.float32),
+            arms_q=np.asarray(arms_q, dtype=np.float32),
+            legs_dq=np.asarray(legs_dq, dtype=np.float32),
+            waist_dq=np.asarray(waist_dq, dtype=np.float32),
+            arms_dq=np.asarray(arms_dq, dtype=np.float32),
+        )
+        # Pre-warm: on the first tick, fill the history with copies of
+        # this frame rather than letting `_build_full_obs` zero-pad
+        # (WBC was trained on continuous trajectories).
+        if not self._history:
+            for _ in range(self.OBS_HISTORY):
+                self._history.append(single.copy())
+        else:
+            self._history.append(single.copy())
+        full_obs = self._build_full_obs()
+
+        sess = self._balance if np.linalg.norm(nav) < self.SWITCH_THRESH else self._walk
+        action = sess.run(None, {self._input_name: full_obs[None, :]})[0][0]  # (15,)
+        self._last_action[:] = action  # raw, pre-scale, for next tick's obs
+        return action * self.ACTION_SCALE + self.DEFAULT_ANGLES_15
+
+    # ----------------------------------------------------------------- helpers
+    def _build_single_obs(
+        self,
+        *,
+        nav_cmd: np.ndarray,
+        height_cmd: float,
+        rpy_cmd: np.ndarray,
+        base_ang_vel: np.ndarray,
+        base_quat_xyzw: np.ndarray,
+        projected_gravity: np.ndarray | None,
+        legs_q: np.ndarray,
+        waist_q: np.ndarray,
+        arms_q: np.ndarray,
+        legs_dq: np.ndarray,
+        waist_dq: np.ndarray,
+        arms_dq: np.ndarray,
+    ) -> np.ndarray:
+        o = self._single_obs
+        o[0:3] = nav_cmd * self.CMD_SCALE
+        o[3] = height_cmd
+        o[4:7] = rpy_cmd
+        o[7:10] = base_ang_vel * self.ANG_VEL_SCALE
+        # Prefer the explicit projected_gravity (from IsaacLab's
+        # data.projected_gravity_b) over the quat-based computation.
+        if projected_gravity is not None:
+            o[10:13] = projected_gravity
+        else:
+            q_eff = (
+                _quat_multiply_xyzw(base_quat_xyzw, self._calibration_inv)
+                if self._calibration_inv is not None
+                else base_quat_xyzw
+            )
+            o[10:13] = _project_gravity(q_eff)
+
+        # 29-D qj = legs (12) + waist (3) + arms (14), minus padded defaults.
+        qj = np.concatenate([legs_q, waist_q, arms_q]).astype(np.float32)
+        o[13 : 13 + self.NUM_BODY_DOF] = (qj - self._padded_defaults) * self.DOF_POS_SCALE
+
+        dqj = np.concatenate([legs_dq, waist_dq, arms_dq]).astype(np.float32)
+        o[13 + self.NUM_BODY_DOF : 13 + 2 * self.NUM_BODY_DOF] = dqj * self.DOF_VEL_SCALE
+
+        o[13 + 2 * self.NUM_BODY_DOF :] = self._last_action
+        return o
+
+    def _build_full_obs(self) -> np.ndarray:
+        n = len(self._history)
+        if n < self.OBS_HISTORY:
+            pad = self.OBS_HISTORY - n
+            self._obs_buf[: pad * self.SINGLE_OBS_DIM] = 0.0
+            offset = pad * self.SINGLE_OBS_DIM
+        else:
+            offset = 0
+        for frame in self._history:
+            self._obs_buf[offset : offset + self.SINGLE_OBS_DIM] = frame
+            offset += self.SINGLE_OBS_DIM
+        return self._obs_buf

--- a/sim_main.py
+++ b/sim_main.py
@@ -53,6 +53,11 @@ parser.add_argument("--profile_interval", type=int, default=500, help="performan
 parser.add_argument("--model_path", type=str, default="assets/model/policy.onnx", help="model path")
 parser.add_argument("--reward_interval", type=int, default=10, help="step interval for reward calculation")
 parser.add_argument("--enable_wholebody_dds", action="store_true", default=False, help="enable wh dds")
+parser.add_argument("--wbc_internal", action="store_true", default=False,
+                    help="Run NVIDIA GR00T-WholeBodyControl Balance/Walk ONNX inside the "
+                         "action_provider (no DDS round-trip). Locomotion commands still "
+                         "come from rt/run_command/cmd. WBC starts driving legs from "
+                         "tick 1 — bundled policy.onnx is disabled.")
 
 parser.add_argument("--physics_dt", type=float, default=None, help="physics time step, e.g., 0.005")
 parser.add_argument("--render_interval", type=int, default=None, help="render interval steps (>=1)")


### PR DESCRIPTION
# Add `--wbc_internal` to run GR00T-WBC Balance/Walk ONNX in-process

## Problem

When an external controller drives legs+waist over `rt/lowcmd` (e.g.
a separate WBC composer or VR teleop bridge), the sim spends the
first second of startup with no leg controller engaged at all. DDS
discovery + the external process's own init take ~300–500 ms, and the
sim's bundled `policy.onnx` is bypassed in that mode, so during that
window the only thing pinning the legs is gravity. Result: the robot
tips before the first external command lands.

Symptom on `Isaac-Move-Cylinder-G129-Dex3-Wholebody`:

```
[t=0.00s] root_quat_w = [1.000, 0.000, 0.000, 0.000]   # upright
[t=0.45s] root_quat_w = [0.831, 0.014, 0.556, 0.020]   # tipped ~68° pitch
```

By the time the external publisher's first `rt/lowcmd` frame arrives,
the WBC is being asked to recover from a state it was never trained
on, and the robot falls.

The bundled `policy.onnx` doesn't suffer this because it runs
synchronously inside `action_provider_wh_dds.DDSRLActionProvider` from
the very first `get_action()` call. We want the GR00T-WBC checkpoints
to enjoy the same "controller engaged from tick 1" property.

## Reproducer

Pre-condition: download
[`GR00T-WholeBodyControl-Balance.onnx`](https://huggingface.co/nvidia/GR00T-WholeBodyControl/blob/main/Balance.onnx)
and
[`GR00T-WholeBodyControl-Walk.onnx`](https://huggingface.co/nvidia/GR00T-WholeBodyControl/blob/main/Walk.onnx)
into `assets/model/groot_wbc/` (or set `GROOT_WBC_ONNX_DIR` to a
custom directory).

Baseline (external controller via DDS, no `--wbc_internal`):

```bash
# Terminal A: sim with the bundled policy bypassed but no in-process WBC
python sim_main.py \
  --task Isaac-Move-Cylinder-G129-Dex3-Wholebody \
  --enable_dex3_dds --enable_wholebody_dds \
  --action_source dds_wholebody
# Terminal B: external WBC publisher (any process that writes
# legs+waist into rt/lowcmd[0..14] from GR00T-WBC)
```

The robot tips before Terminal B's first frame lands. `root_quat_w`
reads non-identity by the time the first external `lowcmd` is received.

With this PR (`--wbc_internal` runs WBC in the sim process):

```bash
python sim_main.py \
  --task Isaac-Move-Cylinder-G129-Dex3-Wholebody \
  --enable_dex3_dds --enable_wholebody_dds \
  --action_source dds_wholebody \
  --wbc_internal
```

No external publisher needed for legs; the locomotion command still
arrives via `rt/run_command/cmd`. Robot stays upright from tick 1.

## Fix

Two-piece change:

1. **`sim_main.py`** — add a `--wbc_internal` argparse flag. Default
   off; existing behavior preserved.

2. **`action_provider/action_provider_wh_dds.py`** — when the flag is
   set, the action provider:
   - Loads `GR00T-WholeBodyControl-{Balance,Walk}.onnx` from
     `$GROOT_WBC_ONNX_DIR` (default
     `$PROJECT_ROOT/assets/model/groot_wbc/`).
   - Skips loading the bundled `policy.onnx` entirely (`self.policy =
     None`).
   - Each tick, reads robot state directly from
     `env.scene["robot"].data.*` (no DDS round-trip — works from tick 1).
   - Builds the canonical 86-D observation (3 cmd + 1 height + 3 rpy +
     3 ang_vel + 3 gravity + 29 qj + 29 dqj + 15 last_action), stacks
     a 6-frame history, runs the Balance ONNX when `|nav_cmd| <
     0.05`, otherwise Walk.
   - Writes the 15-D ONNX output (12 legs + 3 waist) into the
     composite-asset joint targets using name-based USD-index lookup
     (`joint_to_index`).
   - Skips the post-processing `delay/clip/scale` block, because the
     WBC output already has `action_scale` (0.25) + `default_angles`
     applied. Re-applying them would corrupt the command.
   - `nav_cmd` + `height_cmd` still come from `rt/run_command/cmd`
     (same DDS topic the existing `--enable_wholebody_dds` path uses).

3. **`control/lower_body_controller.py` (new)** — vendored
   `LowerBodyController` that owns the two ONNX sessions and the
   6-frame observation history. Pure NumPy + `onnxruntime`; no torch
   dependency. ~250 LOC, self-contained.

## Rationale

- **Mirrors the bundled-policy code path exactly.** WBC inference
  runs inside `DDSRLActionProvider.get_action()` just like
  `self.policy(...)` does. Same lifecycle, same call site, same "drives
  the legs from tick 1" guarantee.
- **No new dependencies.** `onnxruntime` is already a sim requirement
  (used to load the bundled `policy.onnx`). `numpy` is universal.
- **Flag default is off.** All existing launch configurations behave
  identically. The bundled policy path is untouched; the `delay/clip/
  scale` block runs unchanged unless `--wbc_internal` is set.
- **No torch dependency in the vendored controller.** Keeps
  `control/lower_body_controller.py` usable from any tooling (CLI
  diagnostics, replay harness, real-robot bridge) without dragging in
  IsaacLab.
- **Checkpoint directory is overridable** via `GROOT_WBC_ONNX_DIR`, so
  operators don't have to drop weights inside the repo if they prefer
  a system-wide cache.

## Verified

- Robot stable for 27+ seconds with `--wbc_internal` standalone
  (no external publisher); steady tilt 9–11° during pure-balance
  hold, well within the recovery envelope of Balance.onnx.
- End-to-end with VLA-driven navigation: publisher writes
  `[vx, vy, omega, height]` to `rt/run_command/cmd`, action_provider
  reads it inside `_wbc_internal_step`, WBC switches between
  Balance↔Walk based on `|nav_cmd|`. Sequence stand → walk → stand
  completes a 36-second run without falling.
- With `--wbc_internal` off, the bundled-policy code path is
  byte-identical (verified by no-op diff of `get_action` when the
  flag is false).

## Notes for reviewers

- The vendored `LowerBodyController` deliberately keeps the
  observation construction simple and readable so reviewers can
  cross-check the 86-D layout against the GR00T-WBC training config.
  It matches NVIDIA's `g1_gear_wbc_policy.compute_observation` for the
  cases this PR exercises.
- `LowerBodyController.calibrate_spawn_quat` is exposed for assets
  whose root link has a non-anatomical basis (the `projected_gravity`
  fallback path uses it). The default path uses IsaacLab's
  `data.projected_gravity_b` directly, which is canonical and needs
  no calibration.
- `_wbc_internal_step` uses `data.joint_pos`, `data.joint_vel`,
  `data.root_quat_w`, `data.projected_gravity_b`, `data.root_ang_vel_b`
  — all stable IsaacLab APIs.
