### PR TITLE
Fix: Dockerfile global installation compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,6 @@ ARG https_proxy
 ENV http_proxy=${http_proxy}
 ENV https_proxy=${https_proxy}
 
-# 使用阿里云源
-RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.aliyun.com/ubuntu/|g' /etc/apt/sources.list && \
-    sed -i 's|http://security.ubuntu.com/ubuntu/|http://mirrors.aliyun.com/ubuntu/|g' /etc/apt/sources.list
-
-
 # 安装构建依赖（GCC 12 + GLU + Vulkan）
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc-12 g++-12 cmake build-essential unzip git-lfs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /home/code
 # 克隆并安装 IsaacLab
 RUN git clone https://github.com/isaac-sim/IsaacLab.git && \
     cd IsaacLab && \
-    ./isaaclab.sh --install
+    echo "Yes" | ./isaaclab.sh --install
     
 # 构建 CycloneDDS
 RUN git clone https://github.com/eclipse-cyclonedds/cyclonedds -b releases/0.10.x /cyclonedds && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ ENV OMNI_KIT_DISABLE_STARTUP=1
 # 安装运行时依赖
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libglu1-mesa git-lfs zenity unzip \
+    libxt6 libxrandr2 libxcursor1 libxi6 libxinerama1 libxxf86vm1 \
     && rm -rf /var/lib/apt/lists/*
 
 # 复制 Conda 环境和代码

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ ENV OMNI_KIT_DISABLE_STARTUP=1
 
 # 安装运行时依赖
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libglu1-mesa git-lfs zenity unzip \
+    libglu1-mesa git-lfs zenity unzip openssl \
     libxt6 libxrandr2 libxcursor1 libxi6 libxinerama1 libxxf86vm1 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -105,6 +105,13 @@ COPY --from=builder /home/code/unitree_sdk2_python /home/code/unitree_sdk2_pytho
 COPY --from=builder /cyclonedds /cyclonedds
 COPY --from=builder /opt/conda /opt/conda
 COPY --from=builder /home/code/unitree_sim_isaaclab /home/code/unitree_sim_isaaclab
+
+# 生成 WebRTC 所需的自签名 TLS 证书
+RUN openssl req -x509 -newkey rsa:2048 \
+    -keyout /home/code/unitree_sim_isaaclab/teleimager/key.pem \
+    -out /home/code/unitree_sim_isaaclab/teleimager/cert.pem \
+    -days 3650 -nodes -subj "/CN=localhost" \
+    -addext "subjectAltName=IP:127.0.0.1"
 
 
 ENV CYCLONEDDS_HOME=/cyclonedds/install


### PR DESCRIPTION
## Summary
Four fixes to make the Docker image build and run correctly outside of the original Chinese network environment:

- Remove Aliyun mirror redirect — `mirrors.aliyun.com` is unreachable globally, causing `apt-get update` to fail immediately
- Answer the IsaacLab EULA prompt during build — `./isaaclab.sh --install` hangs waiting for interactive input, causing an EOF build failure
- Add missing X11/GL runtime libraries — `libXt.so.6` and related X11 libs are required by Isaac Sim's MaterialX and USD plugins but were absent from the runtime stage
- Generate self-signed TLS cert at build time — the WebRTC image server requires an SSL certificate (`teleimager/cert.pem` + `key.pem`) to start; without it every camera publish call fails with `[Errno 2] No such file or directory`

## Test plan
- [x] `docker build -t unitree-sim:latest -f Dockerfile .` completes without error (no proxy needed)
- [x] Container starts and `python sim_main.py --device cuda --enable_cameras --task Isaac-PickPlace-Cylinder-G129-Dex3-Joint --enable_dex3_dds --robot_type g129` runs without libXt or WebRTC cert errors
